### PR TITLE
 Fix for New-Password endless loop on .Net Core

### DIFF
--- a/Private/ConvertFrom-SecurePassword.ps1
+++ b/Private/ConvertFrom-SecurePassword.ps1
@@ -2,5 +2,5 @@ function ConvertFrom-SecurePassword {
     param (
         [Parameter(Position=0,Mandatory=$true,ValueFromPipeline=$true)][SecureString]$Password
     )
-    return [System.Runtime.InteropServices.Marshal]::PtrToStringAuto([System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($Password))
+    return [System.Runtime.InteropServices.Marshal]::PtrToStringUni([System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($Password))
 }

--- a/Public/New-Password.ps1
+++ b/Public/New-Password.ps1
@@ -91,7 +91,7 @@ function New-Password {
     $DigList = "0123456789"
     $LowList = "abcdefghijklmnopqrstuvwxyz"
     $CapList = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
-    $SymList = "!`"#$%&'()*+,-./:;<=>?@[\]^_``{|}~ "
+    $SymList = "!`"#$%&'()*+,-./:;<=>?@[\]^_{|}~ "
     
     switch ($psCmdlet.ParameterSetName) {
         "Simple" {
@@ -149,7 +149,7 @@ function New-Password {
                 Default {$SecPwd.AppendChar(($WhiList.ToCharArray() | Get-Random)); $WorkSet.Length += -1; break}
             }
         }
-    } while (([System.Runtime.InteropServices.Marshal]::PtrToStringAuto([System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($SecPwd)) | Get-StringEntropy) -lt $Entropy)
+    } while (([System.Runtime.InteropServices.Marshal]::PtrToStringUni([System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($SecPwd)) | Get-StringEntropy) -lt $Entropy)
 
     return $SecPwd
 }

--- a/Public/New-Password.ps1
+++ b/Public/New-Password.ps1
@@ -149,23 +149,7 @@ function New-Password {
                 Default {$SecPwd.AppendChar(($WhiList.ToCharArray() | Get-Random)); $WorkSet.Length += -1; break}
             }
         }
-
-        $SecPwdString = [System.Runtime.InteropServices.Marshal]::PtrToStringAuto([System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($SecPwd))
-
-        if ($SecPwdString.Length -ne $SecPwd.Length) {
-            # Workaround for incorrectly working Marshal.PtrToStringAuto method in .Net Core
-            # if you don't specify Len in 'public static string PtrToStringAuto (IntPtr ptr, int len)' only 1 character is returned
-            $PwdAllocationLength = $SecPwd.Length
-            do {
-                $SecPwdString = [System.Runtime.InteropServices.Marshal]::PtrToStringAuto([System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($SecPwd), $PwdAllocationLength)
-                $SecPwdString = $SecPwdString -replace "$([char]0)"
-                $PwdAllocationLength ++
-            } until ($SecPwdString.Length -eq $SecPwd.Length)
-        }  
-
-        # Verify the string entropy
-        $ResultingEntropy = ($SecPwdString | Get-StringEntropy)
-    } while ($ResultingEntropy -lt $Entropy)
+    } while (([System.Runtime.InteropServices.Marshal]::PtrToStringAuto([System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($SecPwd)) | Get-StringEntropy) -lt $Entropy)
 
     return $SecPwd
 }


### PR DESCRIPTION
Hello Pavel,
I've been enjoying your module a lot until I discovered a problem when it runs on powershell core.
After some research I implemented the fix, that resolves this issue.
I also removed ` powershell escaping symbol from the generating string, since it causes issues

Please let me know what you think.
I'm sorry for the mess in commits. I was going to implement a workaround in the first place.